### PR TITLE
Add new command to checkout branch of remote repository

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -33,6 +33,7 @@
 
     { "caption": "Git: Checkout", "command": "git_checkout_branch"},
     { "caption": "Git: Checkout New Branch", "command": "git_checkout_new_branch"},
+    { "caption": "Git: Checkout Remote Branch", "command": "git_checkout_remote_branch"},
     { "caption": "Git: Checkout Commit", "command": "git_checkout_commit"},
     { "caption": "Git: Checkout Tag", "command": "git_checkout_tag"},
     { "caption": "Git: Checkout Current File", "command": "git_checkout_current_file"},

--- a/sgit/__init__.py
+++ b/sgit/__init__.py
@@ -53,7 +53,7 @@ from .tag import GitTagCommand, GitAddTagCommand
 
 from .checkout import (GitCheckoutBranchCommand, GitCheckoutCommitCommand,
                        GitCheckoutNewBranchCommand, GitCheckoutCurrentFileCommand,
-                       GitCheckoutTagCommand)
+                       GitCheckoutTagCommand, GitCheckoutRemoteBranchCommand)
 
 from .merge import GitMergeCommand
 

--- a/sgit/checkout.py
+++ b/sgit/checkout.py
@@ -12,9 +12,7 @@ from .helpers import GitTagHelper
 
 GIT_BRANCH_EXISTS_MSG = "The branch %s already exists. Do you want to overwrite it?"
 
-# start for GitCheckoutRemoteBranchCommand
 NO_REMOTES = u"No remotes have been configured. Remotes can be added with the Git: Add Remote command. Do you want to add a remote now?"
-# end for GitCheckoutRemoteBranchCommand
 
 class GitCheckoutWindowCmd(GitCmd, GitBranchHelper, GitLogHelper, GitErrorHelper):
     pass
@@ -206,10 +204,15 @@ class GitCheckoutRemoteBranchCommand(WindowCommand, GitCheckoutWindowCmd, GitRem
             if not remote_branches:
                 return sublime.error_message("No branches on remote %s" % remote)
 
-            branches = self.format_quick_branches(remote_branches)
+            formatted_remote_branches = self.format_quick_branches(remote_branches)
+            local_branches = [b for _, b in self.get_branches(repo)]
+            remote_only_branches = [b for b in formatted_remote_branches if b[0] not in frozenset(local_branches)]
+
+            if not remote_only_branches:
+                return sublime.error_message("All remote branches are already present locally")
 
             def on_remote():
-                self.window.show_quick_panel(branches, partial(self.remote_branch_panel_done, repo, branches))
+                self.window.show_quick_panel(remote_only_branches, partial(self.remote_branch_panel_done, repo, remote_only_branches))
 
             sublime.set_timeout(on_remote, 50)
 

--- a/sgit/checkout.py
+++ b/sgit/checkout.py
@@ -6,12 +6,15 @@ from sublime_plugin import WindowCommand, TextCommand
 
 from .util import noop
 from .cmd import GitCmd
-from .helpers import GitStatusHelper, GitBranchHelper, GitErrorHelper, GitLogHelper
+from .helpers import GitStatusHelper, GitBranchHelper, GitErrorHelper, GitLogHelper, GitRemoteHelper
 from .helpers import GitTagHelper
 
 
 GIT_BRANCH_EXISTS_MSG = "The branch %s already exists. Do you want to overwrite it?"
 
+# start for GitCheckoutRemoteBranchCommand
+NO_REMOTES = u"No remotes have been configured. Remotes can be added with the Git: Add Remote command. Do you want to add a remote now?"
+# end for GitCheckoutRemoteBranchCommand
 
 class GitCheckoutWindowCmd(GitCmd, GitBranchHelper, GitLogHelper, GitErrorHelper):
     pass
@@ -177,6 +180,51 @@ class GitCheckoutNewBranchCommand(WindowCommand, GitCheckoutWindowCmd):
         else:
             sublime.error_message(self.format_error_message(stderr))
         self.window.run_command('git_status', {'refresh_only': True})
+
+
+class GitCheckoutRemoteBranchCommand(WindowCommand, GitCheckoutWindowCmd, GitRemoteHelper):
+    """Checkout a remote branch."""
+    def run(self, repo=None):
+        repo = self.get_repo()
+        if not repo:
+            return
+
+        remotes = self.get_remotes(repo)
+        if not remotes:
+            if sublime.ok_cancel_dialog(NO_REMOTES, 'Add Remote'):
+                self.window.run_command('git_remote_add')
+                return
+
+        choices = self.format_quick_remotes(remotes)
+        self.window.show_quick_panel(choices, partial(self.remote_panel_done, repo, choices))
+
+    def remote_panel_done(self, repo, choices, idx):
+        if idx != -1:
+            remote = choices[idx][0]
+
+            remote_branches = self.get_remote_branches(repo, remote)
+            if not remote_branches:
+                return sublime.error_message("No branches on remote %s" % remote)
+
+            branches = self.format_quick_branches(remote_branches)
+
+            def on_remote():
+                self.window.show_quick_panel(branches, partial(self.remote_branch_panel_done, repo, branches))
+
+            sublime.set_timeout(on_remote, 50)
+
+    def remote_branch_panel_done(self, repo, branches, idx):
+        if idx != -1:
+            branch = branches[idx][0]
+
+            exit, stdout, stderr = self.git(['checkout', branch], cwd=repo)
+            if exit == 0:
+                panel = self.window.get_output_panel('git-checkout')
+                panel.run_command('git_panel_write', {'content': stderr})
+                self.window.run_command('show_panel', {'panel': 'output.git-checkout'})
+            else:
+                sublime.error_message(self.format_error_message(stderr))
+            self.window.run_command('git_status', {'refresh_only': True})
 
 
 class GitCheckoutCurrentFileCommand(TextCommand, GitCmd, GitStatusHelper):


### PR DESCRIPTION
This is a feature that I've wanted in `SublimeGit` for quite a while, so I built it and have deployed it locally: `Git: Checkout Remote Branch`. I know there are some others who were hoping for a similar feature ( it's Issue #29 ), so I figured I'd submit it as a pull request. As implemented, it's perfect for my use-cases, but if you think any piece of it would be a valuable contribution to the core project, I'd be happy to adjust the implementation as needed to make it suitable for inclusion. 

If you have other plans or if for any other reason this isn't of interest, don't worry about it. If you'd like a detailed description of this change, I've included it in this [commit message](https://github.com/TJKresch/SublimeGit/commit/c541f87dafd37d95647656b3f5a9aa4b339d5e72)

Thanks!
