### PR TITLE
Add Panel for Diff Current File and Checkout Current File

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -15,7 +15,6 @@
     { "caption": "Git: Diff", "command": "git_diff"},
     { "caption": "Git: Diff Cached", "command": "git_diff_cached"},
     { "caption": "Git: Diff Current File", "command": "git_diff_current_file"},
-    { "caption": "Git: Diff Cached Current File", "command": "git_diff_cached_current_file"},
 
     { "caption": "Git: Add Current File", "command": "git_add_current_file"},
     { "caption": "Git: Quick Add", "command": "git_quick_add"},

--- a/sgit/__init__.py
+++ b/sgit/__init__.py
@@ -13,7 +13,7 @@ from .custom import GitCustomCommand, GitCustomOutputCommand
 
 from .diff import (GitDiffCommand, GitDiffCachedCommand, GitDiffRefreshCommand, GitDiffMoveCommand,
                    GitDiffChangeHunkSizeCommand, GitDiffStageUnstageHunkCommand, GitDiffCurrentFileCommand,
-                   GitDiffCachedCurrentFileCommand, GitDiffEventListener)
+                   GitDiffEventListener)
 
 from .show import GitShowCommand, GitShowRefreshCommand
 

--- a/sgit/checkout.py
+++ b/sgit/checkout.py
@@ -198,7 +198,7 @@ class GitCheckoutCurrentFileCommand(TextCommand, GitCmd, GitStatusHelper, GitLog
             sublime.error_message("The file %s is not tracked by git." % filename.replace(repo, '').lstrip('/'))
             return
 
-        log = self.get_quick_log(repo, path=filename, follow=True)
+        log = self.get_quick_log(repo, path=filename, extra=['--follow'])
         hashes, choices = self.format_quick_log(log)
 
         def on_done(idx):
@@ -215,4 +215,3 @@ class GitCheckoutCurrentFileCommand(TextCommand, GitCmd, GitStatusHelper, GitLog
                 sublime.error_message('git error: %s' % stderr)
 
         self.view.window().show_quick_panel(choices, on_done)
-

--- a/sgit/diff.py
+++ b/sgit/diff.py
@@ -112,7 +112,7 @@ class GitDiffCurrentFileCommand(GitCmd, GitStatusHelper, TextCommand, GitLogHelp
             sublime.error_message('The file %s is not tracked by git.' % filename.replace(repo, '').lstrip('/'))
             return
 
-        log = self.get_quick_log(repo, path=filename, follow=True)
+        log = self.get_quick_log(repo, path=filename, extra=['--follow'])
         hashes, choices = self.format_quick_log(log)
 
         index_changes = bool(self.get_diff(repo, filename, True))

--- a/sgit/helpers.py
+++ b/sgit/helpers.py
@@ -387,10 +387,10 @@ class GitLogHelper(object):
                             '%ar'    # auth date relative
                             '%x04')
 
-    def get_quick_log(self, repo, path=None, follow=False):
-        cmd = ['log', '--no-color', '--date=local', '--format=%s' % self.GIT_QUICK_LOG_FORMAT]
-        if follow:
-            cmd.append('--follow')
+    def get_quick_log(self, repo, path=None, extra=None):
+        cmd = ['log', '--no-color', '--no-merges', '--date=local', '--format=%s' % self.GIT_QUICK_LOG_FORMAT]
+        if extra:
+            cmd.extend(extra)
         if path:
             cmd.extend(['--', path])
         out = self.git_string(cmd, cwd=repo, strip=False)

--- a/sgit/helpers.py
+++ b/sgit/helpers.py
@@ -357,14 +357,15 @@ class GitStatusHelper(object):
 
 class GitDiffHelper(object):
 
-    def get_diff(self, repo, path=None, cached=False, unified=None):
+    def get_diff(self, repo, path=None, cached=False, unified=None, obj=None):
         try:
             unified = int(unified)
         except:
             unified = None
         args = ['diff',
                 '--cached' if cached else None,
-                '--unified=%s' % unified if unified else None]
+                '--unified=%s' % unified if unified else None,
+                obj]
         if path:
             args.extend(['--', path])
         return self.git_string(args, cwd=repo, strip=False)

--- a/sgit/log.py
+++ b/sgit/log.py
@@ -55,7 +55,7 @@ class GitQuickLogCurrentFileCommand(TextCommand, GitCmd, GitLogHelper):
         if not repo:
             return
 
-        log = self.get_quick_log(repo, path=filename, follow=True)
+        log = self.get_quick_log(repo, path=filename, extra=['--follow'])
         hashes, choices = self.format_quick_log(log)
 
         def on_done(idx):


### PR DESCRIPTION
Currently it was only possible to diff against either the cache or the working directory. This pull request contains a commit which allows diffs against other older revisions in the log.

Similarly, checkout only allowed checking out the current file from HEAD. This pull request contains a commit which allows checking the current file out from some other revision in the log.