### PR TITLE
Added strip CR line endings

### DIFF
--- a/sgit/git_extensions/legit.py
+++ b/sgit/git_extensions/legit.py
@@ -31,6 +31,7 @@ class LegitWindowCmd(LegitCmd):
                 continue
             current = l[0:2]
             name, pub = l[2:].split(None, 1)
+            pub = pub.strip('\r')
             pub = pub.strip(' \t()')
             if not pub in filter:
                 continue


### PR DESCRIPTION
Added a line to strip line endings from pub variable which caused problems for sublime commands Legit: Switch and Legit: Branches on Windows by showing only the last branch in the list.