### PR TITLE
git-flow cmds do not work out of the box when git-flow is installed

### DIFF
--- a/SublimeGit.sublime-settings
+++ b/SublimeGit.sublime-settings
@@ -170,8 +170,7 @@
      * ['git', 'flow']
      */
     "git_executables": {
-        "git": ["git"],
-        "git_flow": ["git-flow"],
+        "git": ["git"],        
         "legit": ["legit"],
         "gitk": ["gitk"]
     },

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -101,7 +101,6 @@ After performing these changes, your user settings might look like this::
     {
         "git_executables": {
             "git": ["/usr/local/bin/git"],
-            "git_flow": ["/usr/local/bin/git", "flow"],
             "legit": ["legit"]
         }
     }

--- a/sgit/cmd.py
+++ b/sgit/cmd.py
@@ -216,8 +216,9 @@ class GitCmd(GitRepoHelper, Cmd):
 
 
 class GitFlowCmd(GitRepoHelper, Cmd):
-    executable = 'git_flow'
-    bin = ['git-flow']
+    executable = 'git'
+    bin = ['git']
+    opts = ['flow']
 
     def git_flow(self, cmd, *args, **kwargs):
         return self.cmd(cmd, *args, **kwargs)


### PR DESCRIPTION
With the changes i made the git-flow command will work out of the box if git-flow is installed. Like this there is no need to setup the "git_executables" for "git_flow" in the user settings. 