### PR TITLE
Support for edit hunks manually from diff view

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -273,5 +273,12 @@
         "context": [
             { "key": "selector", "operator": "equal", "operand": "source.git-diff"}
         ]
+    },
+
+    // Edit hunk
+    { "keys": ["e"], "command": "git_diff_edit_hunk",
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "source.git-diff"}
+        ]
     }
 ]

--- a/sgit/__init__.py
+++ b/sgit/__init__.py
@@ -13,7 +13,7 @@ from .custom import GitCustomCommand, GitCustomOutputCommand
 
 from .diff import (GitDiffCommand, GitDiffCachedCommand, GitDiffRefreshCommand, GitDiffMoveCommand,
                    GitDiffChangeHunkSizeCommand, GitDiffStageUnstageHunkCommand, GitDiffCurrentFileCommand,
-                   GitDiffCachedCurrentFileCommand, GitDiffEventListener)
+                   GitDiffCachedCurrentFileCommand, GitDiffEditHunkCommand, GitDiffEventListener)
 
 from .show import GitShowCommand, GitShowRefreshCommand
 


### PR DESCRIPTION
From diff view you can increase and decrease the context (`<+>`, `<->`) of the hunks for stage (`<s>`) them individually. This pull request add the option to edit the hunk <e> to solve the cases when the decrease context it isn't sufficient and allows you to correct the hunk to stage the exact lines, similar to the editing hunks with the command `git add -p`