### PR TITLE
STDERR gets redirected to STDOUT to get the output of failing git

### DIFF
--- a/sgit/cmd.py
+++ b/sgit/cmd.py
@@ -101,7 +101,7 @@ class Cmd(object):
             proc = subprocess.Popen(command,
                                     stdin=subprocess.PIPE,
                                     stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,
+                                    stderr=subprocess.STDOUT,
                                     startupinfo=self.startupinfo(),
                                     env=environment)
             stdout, stderr = proc.communicate(stdin)


### PR DESCRIPTION
commands to the panel

For example running git flow feature start doesnt work if git flow init did not happen but the reason why it fails is not shown anywhere without this change. 