### PR TITLE
Fix For Issue-#209

### DIFF
--- a/SublimeGit.sublime-settings
+++ b/SublimeGit.sublime-settings
@@ -36,6 +36,16 @@
     "git_show_status_help": true,
 
     /*
+     * Show stashes in Git Status
+     *
+     * If set to true, the stashes are shown. 
+     * On Windows getting stashes takes a vew seconds why this slows down
+     * the git status view. You might want to set it to false if you do 
+     * not need the stashes. 
+     */
+    "git_status_stashes": true,
+
+    /*
      * Update Status View on Focus
      *
      * If set to true, the status view will be updated whenever

--- a/sgit/status.py
+++ b/sgit/status.py
@@ -114,7 +114,9 @@ class GitStatusBuilder(GitCmd, GitStatusHelper, GitRemoteHelper, GitStashHelper)
         # update index
         self.git_exit_code(['update-index', '--refresh'], cwd=repo)
 
-        status += self.build_stashes(repo)
+        if get_setting('git_status_stashes') is True:
+            status += self.build_stashes(repo)
+
         status += self.build_files_status(repo)
 
         if get_setting('git_show_status_help', True):


### PR DESCRIPTION
`git stash list `takes several seconds on windows and due to that slows down the git status command. With the new settings users could on their own define if they want stashes in git status or not 