### PR TITLE
Show unmerged files, add checkout ours/theirs shortcut, add merge abort command

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -38,6 +38,7 @@
     { "caption": "Git: Checkout Tag", "command": "git_checkout_tag"},
     { "caption": "Git: Checkout Current File", "command": "git_checkout_current_file"},
     { "caption": "Git: Merge", "command": "git_merge"},
+    { "caption": "Git: Abort Merge", "command": "git_merge_abort"},
 
     { "caption": "Git: Add Remote", "command": "git_remote_add"},
     { "caption": "Git: Remote", "command": "git_remote"},

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -162,6 +162,28 @@
         ]
     },
 
+    // Merge commands
+    { "keys": ["o"], "command": "git_status_checkout", "args": {"discard": "item", "which": "ours"},
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "meta.git-status.line"}
+        ]
+    },
+    { "keys": ["O"], "command": "git_status_checkout", "args": {"discard": "all", "which": "ours"},
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "text.git-status"}
+        ]
+    },
+    { "keys": ["t"], "command": "git_status_checkout", "args": {"discard": "item", "which": "theirs"},
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "meta.git-status.line"}
+        ]
+    },
+    { "keys": ["T"], "command": "git_status_checkout", "args": {"discard": "all", "which": "theirs"},
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "text.git-status"}
+        ]
+    },
+
     // Stashes
     { "keys": ["z"], "command": "git_stash",
         "context": [

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -59,6 +59,7 @@ Branching and Merging
 .. autowindowcmd:: sgit.checkout.GitCheckoutCommitCommand
 .. autowindowcmd:: sgit.checkout.GitCheckoutNewBranchCommand
 .. autowindowcmd:: sgit.merge.GitMergeCommand
+.. autowindowcmd:: sgit.merge.GitMergeAbortCommand
 
 
 Working with Remotes

--- a/docs/keyboard_shortcuts.rst
+++ b/docs/keyboard_shortcuts.rst
@@ -31,6 +31,13 @@ Committing
 * ``enter``: Open file
 * ``d``: View diff
 
+Merging
+~~~~~~~
+* ``o``: Checkout --ours
+* ``O``: Checkout --ours all files
+* ``t``: Checkout --theirs
+* ``T``: Checkout --theirs all files
+
 Stashes
 ~~~~~~~
 * ``a``: Apply stash

--- a/sgit/__init__.py
+++ b/sgit/__init__.py
@@ -36,7 +36,7 @@ from .status import (GitStatusCommand, GitStatusRefreshCommand, GitQuickStatusCo
                      GitStatusUnstageCommand, GitStatusDiscardCommand,
                      GitStatusOpenFileCommand, GitStatusDiffCommand,
                      GitStatusIgnoreCommand, GitStatusStashCmd, GitStatusStashApplyCommand,
-                     GitStatusStashPopCommand)
+                     GitStatusStashPopCommand, GitStatusCheckoutCommand)
 from .status import GitStatusBarEventListener, GitStatusEventListener
 
 from .add import GitQuickAddCommand, GitAddCurrentFileCommand

--- a/sgit/__init__.py
+++ b/sgit/__init__.py
@@ -55,7 +55,7 @@ from .checkout import (GitCheckoutBranchCommand, GitCheckoutCommitCommand,
                        GitCheckoutNewBranchCommand, GitCheckoutCurrentFileCommand,
                        GitCheckoutTagCommand, GitCheckoutRemoteBranchCommand)
 
-from .merge import GitMergeCommand
+from .merge import GitMergeCommand, GitMergeAbortCommand
 
 from .gitk import GitGitkCommand
 

--- a/sgit/helpers.py
+++ b/sgit/helpers.py
@@ -299,6 +299,12 @@ class GitStatusHelper(object):
     def has_unstaged_changes(self, repo):
         return self.git_exit_code(['diff', '--exit-code', '--quiet'], cwd=repo) != 0
 
+    def has_unmerged_changes(self, repo):
+        return self.git_exit_code(['diff', '--exit-code', '--quiet', '--diff-filter=U'], cwd=repo) != 0
+
+    def is_merging(self, repo):
+        return os.path.exists(os.path.join(repo, '.git', 'MERGE_HEAD'))
+
     # def get_porcelain_status(self, repo):
     #     mode = self.get_untracked_mode()
     #     cmd = ['status', '--porcelain', ('--untracked-files=%s' % mode) if mode else None]

--- a/sgit/helpers.py
+++ b/sgit/helpers.py
@@ -325,13 +325,13 @@ class GitStatusHelper(object):
         return lines
 
     def get_files_status(self, repo):
-        untracked, unstaged, staged = [], [], []
+        untracked, unstaged, staged, unmerged = [], [], [], []
         status = self.get_porcelain_status(repo)
         for l in status:
             state, filename = l[:2], l[3:]
             index, worktree = state
             if state in ('DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU'):
-                logger.warning("unmerged WTF: %s, %s", state, filename)
+                unmerged.append((state, filename))
             elif state == '??':
                 untracked.append(('?', filename))
             elif state == '!!':
@@ -341,7 +341,7 @@ class GitStatusHelper(object):
                     unstaged.append((worktree, filename))
                 if index != ' ':
                     staged.append((index, filename))
-        return untracked, unstaged, staged
+        return untracked, unstaged, staged, unmerged
 
     def get_untracked_mode(self):
         # get untracked files mode

--- a/sgit/status.py
+++ b/sgit/status.py
@@ -1034,9 +1034,10 @@ class GitStatusDiscardCommand(TextCommand, GitStatusTextCmd):
         return self.git_exit_code(['diff', '--quiet', '--', filename], cwd=repo) == 0
 
     def get_worktree_status(self, repo, filename):
-        output = self.git_string(['diff', '--name-status', '--', filename], cwd=repo)
+        # unmerged files have two lines, normal files only one line
+        output = self.git_lines(['diff', '--name-status', '--', filename], cwd=repo)
         if output:
-            status, _ = output.split('\t')
+            status, _ = output[0].split('\t')
             return status
 
     def get_staging_status(self, repo, filename):

--- a/sgit/status.py
+++ b/sgit/status.py
@@ -74,6 +74,7 @@ STATUS_LABELS = {
 }
 
 GIT_WORKING_DIR_CLEAN = "Nothing to commit (working directory clean)"
+GIT_MERGE_IN_PROGRESS = "Merge in progress (continue or abort)"
 
 GIT_STATUS_HELP = """
 # Movement:
@@ -156,33 +157,38 @@ class GitStatusBuilder(GitCmd, GitStatusHelper, GitRemoteHelper, GitStashHelper)
         if not untracked and not unstaged and not staged and not unmerged:
             status += GIT_WORKING_DIR_CLEAN + "\n"
 
+        if self.is_merging(repo):
+            status += GIT_MERGE_IN_PROGRESS + "\n"
+
         # untracked files
         if untracked:
+            status += "\n" if len(status) != 0 else ""
             status += SECTIONS[UNTRACKED_FILES]
             for s, f in untracked:
                 status += "\t%s\n" % f.strip()
-            status += "\n"
 
         # unstaged changes
         if unstaged:
+            status += "\n" if len(status) != 0 else ""
             status += SECTIONS[UNSTAGED_CHANGES] if staged else SECTIONS[CHANGES]
             for s, f in unstaged:
                 status += "\t%s %s\n" % (STATUS_LABELS[s], f)
-            status += "\n"
 
         # unmerged files
         if unmerged:
+            status += "\n" if len(status) != 0 else ""
             status += SECTIONS[UNMERGED_CHANGES]
             for s, f in unmerged:
                 status += "\t%s %s\n" % (STATUS_LABELS[s], f)
-            status += "\n"
 
         # staged changes
         if staged:
+            status += "\n" if len(status) != 0 else ""
             status += SECTIONS[STAGED_CHANGES]
             for s, f in staged:
                 status += "\t%s %s\n" % (STATUS_LABELS[s], f)
-            status += "\n"
+
+        status += "\n"
 
         return status
 

--- a/sgit/status.py
+++ b/sgit/status.py
@@ -28,7 +28,7 @@ GIT_STATUS_VIEW_SETTINGS = {
 STASHES = "stashes"
 UNTRACKED_FILES = "untracked_files"
 UNSTAGED_CHANGES = "unstaged_changes"
-UNMERGED_CHANGES = "unmerged_CHANGES"
+UNMERGED_CHANGES = "unmerged_changes"
 STAGED_CHANGES = "staged_changes"
 CHANGES = "changes"  # pseudo-section to ignore staging area
 

--- a/sgit/status.py
+++ b/sgit/status.py
@@ -74,7 +74,8 @@ STATUS_LABELS = {
 }
 
 GIT_WORKING_DIR_CLEAN = "Nothing to commit (working directory clean)"
-GIT_MERGE_IN_PROGRESS = "Merge in progress (continue or abort)"
+GIT_MERGE_IN_PROGRESS_UNMERGED = "Merge in progress (fix conflicts or abort)"
+GIT_MERGE_IN_PROGRESS_READY = "Merge in progress (all conflicts resolved; commit to finish merge)"
 
 GIT_STATUS_HELP = """
 # Movement:
@@ -158,7 +159,10 @@ class GitStatusBuilder(GitCmd, GitStatusHelper, GitRemoteHelper, GitStashHelper)
             status += GIT_WORKING_DIR_CLEAN + "\n"
 
         if self.is_merging(repo):
-            status += GIT_MERGE_IN_PROGRESS + "\n"
+            if not unmerged:
+                status += GIT_MERGE_IN_PROGRESS_READY + "\n"
+            else:
+                status += GIT_MERGE_IN_PROGRESS_UNMERGED + "\n"
 
         # untracked files
         if untracked:

--- a/sgit/status.py
+++ b/sgit/status.py
@@ -970,11 +970,13 @@ class GitStatusDiscardCommand(TextCommand, GitStatusTextCmd):
 
     def discard_files(self, repo, files):
         # See if any of the files cannot be discarded
-        error = "You can't discard staged changes to the following files. Please unstage them first:\n\n  {errfiles}"
+        error = "You can't discard staged changes to the following files. Please unstage them or fix merge conflicts first:\n\n  {errfiles}"
         errlist = []
         for s, f in files:
             if s == STAGED_CHANGES and not self.is_up_to_date(repo, f):
-                errlist.append(f)
+                errlist.append('%s (unstage)' % f)
+            elif self.get_worktree_status(repo, f) == 'U':
+                errlist.append('%s (unmerged)' % f)
 
         if errlist:
             errfiles = "\n  ".join(errlist)

--- a/sgit/status.py
+++ b/sgit/status.py
@@ -1043,9 +1043,10 @@ class GitStatusDiscardCommand(TextCommand, GitStatusTextCmd):
             return status
 
     def get_staging_status(self, repo, filename):
-        output = self.git_string(['diff', '--name-status', '--cached', '--', filename], cwd=repo)
+        # unmerged files have two lines, normal files only one line
+        output = self.git_lines(['diff', '--name-status', '--cached', '--', filename], cwd=repo)
         if output:
-            status, _ = output.split('\t')
+            status, _ = output[0].split('\t')
             return status
 
 

--- a/sgit/status.py
+++ b/sgit/status.py
@@ -63,14 +63,14 @@ STATUS_LABELS = {
     'U' : 'Unmerged  ',
     '?' : 'Untracked ',
     '!' : 'Ignored   ',
-    'T' : 'Typechange',
-    'DD': 'Both deleted   ',
-    'AU': 'Added by us    ',
-    'UD': 'Deleted by them',
-    'UA': 'Added by them  ',
-    'DU': 'Deleted by us  ',
-    'AA': 'Both added     ',
-    'UU': 'Both modified  ',
+    'T' : 'Type-Change',
+    'DD': 'Deleted-by-both ',
+    'AU': 'Added-by-Us     ',
+    'UD': 'Deleted-by-Them ',
+    'UA': 'Added-by-Them   ',
+    'DU': 'Deleted-by-Us   ',
+    'AA': 'Added-by-Both   ',
+    'UU': 'Modified-by-Both',
 }
 
 GIT_WORKING_DIR_CLEAN = "Nothing to commit (working directory clean)"

--- a/syntax/SublimeGit Status.JSON-tmLanguage
+++ b/syntax/SublimeGit Status.JSON-tmLanguage
@@ -87,7 +87,7 @@
         },
         {
             "name": "meta.git-status.unstaged_changes",
-            "begin": "^((?:Unstaged changes:\\n)|(?:Changes:\\n))",
+            "begin": "^((?:Unstaged changes:\\n)|(?:Changes:\\n)|(?:Unmerged changes:\\n))",
             "beginCaptures": {
                 "1": { "name": "constant.other.git-status.header" }
             },

--- a/syntax/SublimeGit Status.JSON-tmLanguage
+++ b/syntax/SublimeGit Status.JSON-tmLanguage
@@ -51,7 +51,7 @@
         },
         {
             "name": "meta.git-status.merging",
-            "match": "^(Merge in progress \\(continue or abort\\))\\n",
+            "match": "^(Merge in progress \\((fix conflicts or abort|all conflicts resolved; commit to finish merge)\\))\\n",
             "captures": {
                 "1": { "name": "markup.inserted.git-status.merging" }
             }

--- a/syntax/SublimeGit Status.JSON-tmLanguage
+++ b/syntax/SublimeGit Status.JSON-tmLanguage
@@ -50,6 +50,13 @@
             }
         },
         {
+            "name": "meta.git-status.merging",
+            "match": "^(Merge in progress \\(continue or abort\\))\\n",
+            "captures": {
+                "1": { "name": "markup.inserted.git-status.merging" }
+            }
+        },
+        {
             "name": "meta.git-status.stashes",
             "begin": "^(Stashes:\\n)",
             "beginCaptures": {

--- a/syntax/SublimeGit Status.JSON-tmLanguage
+++ b/syntax/SublimeGit Status.JSON-tmLanguage
@@ -101,7 +101,7 @@
             "patterns": [
                 {
                     "name": "meta.git-status.line",
-                    "match": "\\t(\\w+) *(.+)\\n",
+                    "match": "\\t(\\w+\-) *(.+)\\n",
                     "captures": {
                         "2": { "name": "meta.git-status.file" }
                     }
@@ -118,7 +118,7 @@
             "patterns": [
                 {
                     "name": "meta.git-status.line",
-                    "match": "\\t(\\w+) *(.+)\\n",
+                    "match": "\\t(\\w+\\-) *(.+)\\n",
                     "captures": {
                         "2": { "name": "meta.git-status.file" }
                     }

--- a/syntax/SublimeGit Status.tmLanguage
+++ b/syntax/SublimeGit Status.tmLanguage
@@ -189,7 +189,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^((?:Unstaged changes:\n)|(?:Changes:\n))</string>
+			<string>^((?:Unstaged changes:\n)|(?:Changes:\n)|(?:Unmerged changes:\n))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/syntax/SublimeGit Status.tmLanguage
+++ b/syntax/SublimeGit Status.tmLanguage
@@ -121,7 +121,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(Merge in progress \(continue or abort\))\n</string>
+			<string>^(Merge in progress \((fix conflicts or abort|all conflicts resolved; commit to finish merge)\))\n</string>
 			<key>name</key>
 			<string>meta.git-status.merging</string>
 		</dict>

--- a/syntax/SublimeGit Status.tmLanguage
+++ b/syntax/SublimeGit Status.tmLanguage
@@ -112,6 +112,20 @@
 			<string>meta.git-status.clean</string>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>markup.inserted.git-status.merging</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>^(Merge in progress \(continue or abort\))\n</string>
+			<key>name</key>
+			<string>meta.git-status.merging</string>
+		</dict>
+		<dict>
 			<key>begin</key>
 			<string>^(Stashes:\n)</string>
 			<key>beginCaptures</key>

--- a/syntax/SublimeGit Status.tmLanguage
+++ b/syntax/SublimeGit Status.tmLanguage
@@ -214,7 +214,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\t(\w+) *(.+)\n</string>
+					<string>\t([\w\-]+) *(.+)\n</string>
 					<key>name</key>
 					<string>meta.git-status.line</string>
 				</dict>
@@ -247,7 +247,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\t(\w+) *(.+)\n</string>
+					<string>\t([\w\-]+) *(.+)\n</string>
 					<key>name</key>
 					<string>meta.git-status.line</string>
 				</dict>


### PR DESCRIPTION
 - Fixes unable to see unmerged files in status view (#88 and #263).
 - Adds message in status view to indicate whether a merge is in progress, and whether it is ready to commit.
 - Adds error message when attempting to commit with unmerged changes.
 - Adds error message when attempting to merge when a merge is already in progress.
 - Adds `o`/`O` keyboard shortcut in status view to checkout "ours" version of unmerged files.
 - Adds `t`/`T` keyboard shortcut in status view to checkout "theirs" version of unmerged files.
 - Adds `Abort Merge` command to abort current merge.
 - Committing when a merge is in progress pre-fills the commit message (as native `git commit` would do).